### PR TITLE
[FEAT] 가게 등록 API 구현

### DIFF
--- a/src/main/java/umc/spring/converter/StoreConverter.java
+++ b/src/main/java/umc/spring/converter/StoreConverter.java
@@ -1,0 +1,27 @@
+package umc.spring.converter;
+
+import umc.spring.domain.Store;
+import umc.spring.web.dto.StoreRequestDTO;
+import umc.spring.web.dto.StoreResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class StoreConverter {
+    public static Store toStore(StoreRequestDTO.StoreCreateDto request) {
+        return Store.builder()
+                .name(request.getName())
+                .address(request.getAddress())
+                .score(request.getScore())
+                .build();
+    }
+
+    public static StoreResponseDTO.StoreResultDto toStoreResultDto(Store store) {
+        return StoreResponseDTO.StoreResultDto.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .address(store.getAddress())
+                .score(store.getScore())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
@@ -1,0 +1,10 @@
+package umc.spring.service.StoreService;
+
+import org.springframework.transaction.annotation.Transactional;
+import umc.spring.domain.Store;
+import umc.spring.web.dto.StoreRequestDTO;
+
+public interface StoreCommandService {
+    @Transactional
+    Store createStore(StoreRequestDTO.StoreCreateDto request);
+}

--- a/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
@@ -1,0 +1,25 @@
+package umc.spring.service.StoreService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.spring.converter.StoreConverter;
+import umc.spring.domain.Store;
+import umc.spring.repository.StoreRepository;
+import umc.spring.web.dto.StoreRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreCommandServiceImpl implements StoreCommandService {
+
+    private final StoreRepository storeRepository;
+
+
+    @Override
+    @Transactional
+    public Store createStore(StoreRequestDTO.StoreCreateDto request) {
+        Store store = StoreConverter.toStore(request);
+        return storeRepository.save(store);
+    }
+}

--- a/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -1,0 +1,27 @@
+package umc.spring.web.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.StoreConverter;
+import umc.spring.domain.Store;
+import umc.spring.service.StoreService.StoreCommandService;
+import umc.spring.web.dto.StoreRequestDTO;
+import umc.spring.web.dto.StoreResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores")
+public class StoreRestController {
+    private final StoreCommandService storeCommandService;
+
+    @PostMapping("/")
+    public ApiResponse<StoreResponseDTO.StoreResultDto> createStore(@RequestBody @Valid StoreRequestDTO.StoreCreateDto request) {
+        Store store = storeCommandService.createStore(request);
+        return ApiResponse.onSuccess(StoreConverter.toStoreResultDto(store));
+    }
+}

--- a/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
@@ -1,0 +1,18 @@
+package umc.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StoreRequestDTO {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreCreateDto {
+        private String name;
+        private String address;
+        private Float score;
+    }
+}

--- a/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
+++ b/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class StoreResponseDTO {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreResultDto {
+        private Long storeId;
+        private String name;
+        private String address;
+        private Float score;
+        private LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
1. StoreRequestDTO & StoreResponseDTO 작성
- 가게 추가를 위한 요청 DO 및 응답 DTO 작성

2. StoreRepository 작성
- Store 엔티티를 관리할 JPA 레포지토리 작성

3. StoreService 작성
- 비즈니스 로직을 처리할 서비스 작성. 가게 저장 기능 구현

4. StoreConverter 작성
- StoreRequestDTO를 Store 엔티티로 변환하고, Store 엔티티를 StoreResponseDTO로 변환하는 컨버터 작성

5. StoreRestController 작성
- HTTP 요청을 처리할 컨트롤러 작성. POST 요청을 처리하는 API 작성

--------------
### 다음에 구현하면 좋을 부분

- 가게 목록 조회 API (GET 메서드)
- 가게 삭제 및 수정 기능 API (PUT, DELETE)
